### PR TITLE
Add `top_level_names` config option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ In ``hello/__init__.py``, ``six`` can be imported from ``_vendor``:
 
     from ._vendor import six
 
-Packages that are built not with Setuptools (but for example Flit or Poetry) might not have a `top_level.txt` file
+Packages that are built not with Setuptools (but for example with Poetry) might not have a `top_level.txt` file
 in their distribution info. However, vendorize requires this information to rewrite absolute imports. If you encounter
 that an absolute import is not rewritten as it should have, set the `top_level_names` option in `vendorize.toml`. These
 will be taken into account in addition to any records from `top_level.txt` files.

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,11 @@ In ``hello/__init__.py``, ``six`` can be imported from ``_vendor``:
 
     from ._vendor import six
 
+Packages that are built not with Setuptools (but for example Flit or Poetry) might not have a `top_level.txt` file
+in their distribution info. However, vendorize requires this information to rewrite absolute imports. If you encounter
+that an absolute import is not rewritten as it should have, set the `top_level_names` option in `vendorize.toml`. These
+will be taken into account in addition to any records from `top_level.txt` files.
+
 Installation
 ~~~~~~~~~~~~
 

--- a/vendorize/__init__.py
+++ b/vendorize/__init__.py
@@ -18,13 +18,13 @@ def vendorize_requirements(path):
         requirements=config["packages"],
         target_directory=target_directory,
     )
-    top_level_names = _read_top_level_names(target_directory)
+    top_level_names = _read_top_level_names(target_directory) + config.get("top_level_names", [])
     _rewrite_imports(target_directory, top_level_names)
 
 
-def vendorize_requirement(cwd, requirement, target_directory):
+def vendorize_requirement(cwd, requirement, target_directory, top_level_names):
     _download_requirements(cwd=cwd, requirements=[requirement], target_directory=target_directory)
-    top_level_names = _read_top_level_names(target_directory)
+    top_level_names = _read_top_level_names(target_directory) + (top_level_names or [])
     _rewrite_imports(target_directory, top_level_names)
 
 

--- a/vendorize/__init__.py
+++ b/vendorize/__init__.py
@@ -18,13 +18,13 @@ def vendorize_requirements(path):
         requirements=config["packages"],
         target_directory=target_directory,
     )
-    top_level_names = _read_top_level_names(target_directory) + config.get("top_level_names", [])
+    top_level_names = _read_top_level_names(target_directory) | set(config.get("top_level_names", []))
     _rewrite_imports(target_directory, top_level_names)
 
 
 def vendorize_requirement(cwd, requirement, target_directory, top_level_names):
     _download_requirements(cwd=cwd, requirements=[requirement], target_directory=target_directory)
-    top_level_names = _read_top_level_names(target_directory) + (top_level_names or [])
+    top_level_names = _read_top_level_names(target_directory) | set(top_level_names or [])
     _rewrite_imports(target_directory, top_level_names)
 
 

--- a/vendorize/cli.py
+++ b/vendorize/cli.py
@@ -1,17 +1,41 @@
+import argparse
 import sys
 
 from . import vendorize_requirement, vendorize_requirements
 
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "path_or_requirement",
+    nargs="?",
+    help="path to the TOML configuration file, or a requirement",
+)
+parser.add_argument(
+    "target_directory", nargs="?", help="the directory to put the vendorized package in"
+)
+parser.add_argument(
+    "--top-level-names",
+    help="if the distribution of the package being vendored does not contain a "
+    "top_level.txt file, a comma-separate list of top level names can be specified here. The top level names "
+    "are used to rewrite absolute import statements (only if target_directory is only specified).",
+)
+
 
 def main():
-    if len(sys.argv) < 2:
-        vendorize_requirements(path="vendorize.toml")
-    elif len(sys.argv) < 3:
-        vendorize_requirements(path=sys.argv[1])
+    args = parser.parse_args()
+    if args.target_directory is None:
+        if args.top_level_names:
+            parser.error(
+                "--top-level-names can only be used if a single requirement is vendored"
+            )
+        vendorize_requirements(path=args.path_or_requirement or "vendorize.toml")
     else:
-        requirement = sys.argv[1]
-        target_directory = sys.argv[2]
-        vendorize_requirement(cwd=".", requirement=requirement, target_directory=target_directory)
+        top_level_names = args.top_level_names.split(",") if args.top_level_names else None
+        vendorize_requirement(
+            cwd=".",
+            requirement=args.path_or_requirement,
+            target_directory=args.target_directory,
+            top_level_names=top_level_names,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows to add entries to the top level names that are used to rewrite absolute imports in the vendorized packages. Some packages don't come with a `top_level.txt` (for example if they are built with Poetry).