### PR TITLE
Update __init__.py

### DIFF
--- a/vendorize/__init__.py
+++ b/vendorize/__init__.py
@@ -52,7 +52,7 @@ def vendorize_requirement(cwd, requirement, target_directory):
 
 def _download_requirements(cwd, requirements, target_directory):
     mkdir_p(target_directory)
-    subprocess.check_call(
+    subprocess.call(
         [sys.executable, "-m", "pip", "install", "--no-dependencies", "--target", target_directory] + requirements,
         cwd=cwd)
 


### PR DESCRIPTION
subprocess.check_call() shows information that an error occurred (exit code 1), but it does not indicate the reason for the error. It's better to use subprocess.call(). It was this fix that helped me understand the reason for exit code 1.